### PR TITLE
remove license field and the check that looks for it

### DIFF
--- a/operator-config.yml
+++ b/operator-config.yml
@@ -45,16 +45,6 @@ resources:
     playbook: playbooks/provision-tmdb-wazi.yml
     finalizer: playbooks/deprovision-tmdb-wazi.yml
     vars:
-      - name: accept
-        displayName: License
-        type: boolean
-        required: true
-        description: >-
-          IBM Information Management System Operator Collection license agreement must be accepted during installation of this product.
-          Refer to the IBM Z and Cloud Modernization Stack Community page https://ibm.biz/z-modernization-stack-community to read the corresponding license for 
-          the IBM Z and Cloud Modernization Stack - IMS Operator version selected. 
-          I certify that I have read and accept the terms of the IBM® license that covers the deployment of this software.
-      
       - name: DFS_IMS_SSID
         displayName: SSID
         description: The IMSID of this instance (https://ibm.biz/BdPbuM)

--- a/playbooks/provision-tmdb-wazi.yml
+++ b/playbooks/provision-tmdb-wazi.yml
@@ -19,13 +19,6 @@
 
   tasks:
     - block:
-
-      # check if licence has been accepted and fail if not.
-      - name: License not accepted
-        ansible.builtin.fail:
-          msg: Product license was not accepted
-        when: not accept
-
       - name: Set up Run environment
         include_role:
           name: set_up_run_environment


### PR DESCRIPTION
Removed license field, which is not required now that the operator is open source. Tested and confirmed it works as intended when doing a new install of IMS operator and creation of TMDB instance and upgrading from the old with the license to the new one without the license requirement.